### PR TITLE
[Prefix Sum] 8주차

### DIFF
--- a/rumos/PrefixSum/BOJ_14929.cpp
+++ b/rumos/PrefixSum/BOJ_14929.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+
+using namespace std;
+
+int N;
+long long answer = 0;
+long long prefix_sum = 0;
+
+int main() {
+    // input
+    cin >> N;
+
+    /**
+     * x1y2 + x1y3 + ...
+     * = x1 * (y2 + y3 + ...)
+    */
+
+    // prefix sum
+    int t;
+    while(N--) {
+        cin >> t;
+        answer += t * prefix_sum;
+        prefix_sum += t;
+    }
+
+    cout << answer;
+
+    return 0;
+}

--- a/rumos/PrefixSum/BOJ_1749.cpp
+++ b/rumos/PrefixSum/BOJ_1749.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+long long pSum[201][201];
+
+long long answer = -123456789;
+
+int main() {
+    // input
+    cin >> N >> M;
+    for(int i = 1; i <= N; i++) {
+        for(int j = 1; j <= M; j++) {
+            cin >> pSum[i][j];
+
+            // prefix sum
+            pSum[i][j] += pSum[i][j - 1] + pSum[i - 1][j] - pSum[i - 1][j - 1];
+
+        }
+    }
+
+    // brute force
+    for (int i = 1; i <= N; i++) {
+		for (int j = 1; j <= M; j++) {
+			for (int k = i; k <= N; k++) {
+				for (int l = j; l <= M; l++) {
+					long long current = pSum[k][l] - pSum[k][j - 1] - pSum[i - 1][l] + pSum[i - 1][j - 1];
+					answer = max(answer, current);
+				}
+			}
+		}
+	}
+
+    cout << answer;
+
+    return 0;
+}

--- a/rumos/PrefixSum/BOJ_20438.cpp
+++ b/rumos/PrefixSum/BOJ_20438.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+
+using namespace std;
+
+int N; // 학생의 수
+int K; // 졸고 있는 학생의 수
+int Q; // 출석 코드를 보낼 학생의 수
+int M; // 주어질 구간의 수
+
+bool sleepy[5003];
+int pSum[5003]; // 출석 완료하면 true, 아니면 false
+
+int main() {
+
+    ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+    
+    // input
+    cin >> N >> K >> Q >> M;
+
+    // sleepy check
+    for(int i = 0; i < K; i++) {
+        int num; cin >> num;
+        sleepy[num] = true;      
+    }
+    for(int i = 3; i <= N + 2; i++) pSum[i] = 1;
+
+    // present check
+    for(int i =0; i < Q; i++) {
+        int num;
+        cin >> num;
+
+        if(sleepy[num]) continue; // 조는 학생은 전달할 수 없음
+
+        int next = num; // 다음 학생에게 전달
+
+        while(next <= N + 2) {
+            // 다음 학생이 졸고 있다면 건너뜀
+            if(sleepy[next]) {
+                next += num;
+                continue;
+            }
+
+            // 전달 및 출석
+            pSum[next] = 0;
+            next += num;
+        }
+    }
+
+    // 누적 합으로 i까지의 출석 못 한 학생을 미리 구한다
+    for(int i = 4; i <= N + 2; i++) pSum[i] += pSum[i - 1];
+
+    // 여러 테스트 케이스에 대해 pSum을 출력
+    for(int i = 0; i < M; i++) {
+        int start, end;
+        cin >> start >> end;
+        cout << pSum[end] - pSum[start - 1] << "\n";
+    }
+
+    return 0;
+}

--- a/rumos/PrefixSum/BOJ_20440.cpp
+++ b/rumos/PrefixSum/BOJ_20440.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <algorithm>
+#include <queue>
+
+#define INF -987654321
+
+using namespace std;
+
+int N;
+pair<int, int> arr[1000002];
+priority_queue<int> pq;
+
+int mos = 0;
+int max_mos = INF;
+
+int start_time = INF;
+int end_time = INF;
+
+int main() {
+    // input
+    cin >> N;
+    
+    for(int i = 0; i < N; i++) {
+        cin >> arr[i].first >> arr[i].second;
+    }
+
+    // 배열 정렬
+    sort(arr, arr + N);
+
+    for(int i = 0; i < N; i++) {
+        pq.push(-arr[i].second); // 작은 것이 우선 순위가 높도록
+        mos++;
+
+        // 모기가 들어오는 시간보다 나가는 것이 빠르다면 없앰
+        while(!pq.empty() && -pq.top() <= arr[i].first) {pq.pop(); mos--;}
+
+        // 현재 모기 기준으로 변경
+        if(mos > max_mos) {
+            start_time = arr[i].first;
+            end_time = -pq.top();
+            max_mos = mos;
+
+            int index = i;
+            
+            // 나가는 시간과 들어오는 시간이 같을 때
+            while(i + 1 != N && arr[i].second == arr[i + 1].first)
+                end_time = arr[++i].second;
+        }
+    }
+
+    cout << max_mos << "\n";
+    cout << start_time << " " << end_time << "\n";
+    
+    return 0;
+}

--- a/rumos/PrefixSum/BOJ_21318.cpp
+++ b/rumos/PrefixSum/BOJ_21318.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N; // 악보의 개수
+int level[100001]; // 악보의 난이도
+int mistake[100001]; // i번째에서 실수하면 1
+int pSum[100001]; 
+
+int Q; // 질문의 개수
+
+int main() {
+    ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+    // input
+    cin >> N;
+
+    int temp_level;
+
+    for(int i = 1; i <= N; i++) {
+        cin >> level[i];
+    }
+
+    // prefix sum
+    for(int i = 1; i <= N; i++) {
+        if(i != N && (level[i] > level[i + 1])) mistake[i] = 1;
+    }
+
+    pSum[1] = mistake[1];
+
+    for(int i = 1; i <= N; i++) {
+       pSum[i] = mistake[i] + pSum[i - 1];
+    }
+
+    // question
+    cin >> Q;
+
+    for(int i = 0; i < Q; i++) {
+        int start, end; cin >> start >> end;
+        if(mistake[end] != 1) cout << pSum[end] - pSum[start - 1] << "\n";
+        else cout << pSum[end] - pSum[start - 1] - 1 << "\n";
+    }
+
+    return 0;
+}

--- a/rumos/PrefixSum/BOJ_2167.cpp
+++ b/rumos/PrefixSum/BOJ_2167.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+
+using namespace std;
+
+long long pSum[301][301];
+
+int N, M;
+int K;
+
+int main() {
+    // input
+    cin >> N >> M;
+
+    for(int i = 1; i <= N; i++) {
+        for(int j = 1; j <= M; j++) {
+            cin >> pSum[i][j];
+            pSum[i][j] += pSum[i][j - 1] + pSum[i - 1][j] - pSum[i - 1][j - 1];
+        }
+    }
+
+    // using prefix sum
+    cin >> K;
+    
+    for(int i = 0; i < K; i++) {
+        int x1, y1, x2, y2;
+        cin >> x1 >> y1 >> x2 >> y2;
+        cout << pSum[x2][y2] - pSum[x1 - 1][y2] - pSum[x2][y1 - 1] + pSum[x1 - 1][y1 - 1] << "\n";
+    }
+
+    return 0;
+
+}


### PR DESCRIPTION
## ✅ 체크리스트

<!-- 푼 문제들을 체크해주세요 -->

- [x]  14929 귀찮아 (SIB)
- [x]  2167 2차원 배열의 합
- [x]  20438 출석체크
- [x]  21318 피아노 체조
- [x]  1749 점수따먹기
- [x]  20440 🎵니가 싫어 싫어 너무 싫어 싫어 오지 마 내게 찝쩍대지마🎵 - 1
- [ ]  21757 나누기
- [ ]  20543 폭탄 던지는 태영이

## ✏️ 공부 내용

### 누적 합 (Prefix Sum)

https://book.acmicpc.net/algorithm/prefix-sum
https://jih3508.tistory.com/50

(x1, y1) 부터 (x2, y2)의 합을 영역으로 표시하면 아래 그림과 같다! 
<img width="703" alt="image" src="https://github.com/APS-Alogrithm-Problem-Solving/APS/assets/81238093/e410b3b8-7090-4bff-b9e0-ec14e1fd78f4">

### 14929 귀찮아 (SIB)

`x1y2 + x1y3 + … = x1 * (y2 + y3 + …)` 인 점을 이용하면 누적합을 이용해 시간 제한 안에 해결할 수 있다.

### 20438 출석체크 🔥

`input, output tie`로 인해서 누적합을 잘 사용했음에도 시간 초과가 발생했다. 아래 코드를 써야 하는 경우를 찾아보니, 대부분 input, output이 많으면 무조건 적는 것 같다. 아무리 코드를 뜯어봐도 틀린 구석이 없을 때, 시간 초과가 발생할 때 이걸 의심해야겠다. (지난 번에도 이런 경우가 있었는데, 이번에는 삽질 하지 않고 바로 의심했다! 잡았다 요놈)

```cpp
ios::sync_with_stdio(false);
cin.tie(0);
cout.tie(0);
```

`pSum`에 0, 1로 출석한 학생, 출석하지 못한 학생을 구분하고, O(1)로 돌면서 i까지 출석하지 못한 학생을 한 번에 구한다. 누적 합 개념을 잘 담고 있는 좋은 문제라고 생각한다.

### 21318 피아노 체조

N의 범위를 보고 `vector`로 선언한 다음 `resize` 후 입력을 받았는데, 왜인지 `segmentation fault`가 계속 발생해서 배열로 선언해서 풀었다. 분명 `resize`를 `N+1`만큼 하고, 일반 배열처럼 input을 받았는데 왜 안됐는지 모르겠다. 다른 부분 구현은 금방 됐는데, 이 부분 때문에 시간이 오래 걸렸다.

### 1749 점수따먹기

이차원 배열의 모든 가능한 부분 행렬을 확인하기 위해 무려 **4중 for문**을 이용했다. 이게 최선의 방법일까? 생각했지만 **최댓값을 구하기 위해서는 필연적으로 모든 부분 행렬을 확인해야 했다.**

4중 for문의 시간 복잡도는 다음과 같다.

- i : N번 반복
- j : M번 반복
- k : 최대 N번 반복
- l : 최대 M번 반복
- **O(N^2 * M^2)**

```cpp
  // brute force
  for (int i = 1; i <= N; i++) { 
	for (int j = 1; j <= M; j++) {
		for (int k = i; k <= N; k++) {
			for (int l = j; l <= M; l++) {
				long long current = pSum[k][l] - pSum[k][j - 1] - pSum[i - 1][l] + pSum[i - 1][j - 1];
				answer = max(answer, current);
			}
		}
	}
}
```

### 20440 🎵니가 싫어 싫어 너무 싫어 싫어 오지 마 내게 찝쩍대지마🎵 - 1

현재의 풀이는 온전히 나만의 코드가 아니다… 패기 있게 시작했는데 생각보다 아이디어가 잘 떠오르지 않았다.

코딩테스트에서 종종 쓰이는 스킬인 [좌표 압축]에 대해 알게 되었다. `pair`를 통해서 모기의 입장 시간, 퇴장 시간 좌표를 받아서 정렬한다. 퇴장 시간은 작은 시간이 먼저 오도록 `pq`를 만들고, `pair`를 돌면서 시작 시간일 때마다 `pq`를 비우고 모기를 늘린다.

### imos법

N차원 직교 좌표계에서 특정 구간에 x를 더하는 문제를 풀 때 사용할 수 있다. 같은 쿼리가 연속으로 주어질 때 imos법을 이용하면 일부 좌표를 마킹해 d차원일 때 `O(N^d)` 시간 복잡도로 공간을 채울 수 있다.

설명만 들어서는 잘 이해가 안돼서, 유사한 문제를 많이 풀어봐야 할 것 같다.

- imos 설명 링크 https://nicotina04.tistory.com/163
- 백준 유사 문제 https://www.acmicpc.net/problem/28018

## 💬 논의 사항

프로그래머스 문제도 오랜만에 풀고 싶네요! 제목이 긴 문제는 시작했다가 생각보다 우선순위 큐를 자유자재로 다룰 수 있어야 금방 풀 수 있을 것 같아 pq를 복습해야겠다는 생각을 했습니다…