### PR TITLE
[BruteForce] 12주차

### DIFF
--- a/rumos/BruteForce/BOJ_10971.cpp
+++ b/rumos/BruteForce/BOJ_10971.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+
+using namespace std;
+
+int N;
+int arr[10][10];
+bool city[10] = {false, };
+int answer = 987654321;
+
+/**
+ * N개의 도시를 모두 거쳐 다시 원래의 도시로 돌아와야 함
+*/
+
+void backtracking(int start_node, int current_node, int cnt, int cost) {
+    // stop condition
+    if(cnt == N) {
+        if(arr[current_node][start_node] == 0) return; // 다시 돌아갈 수 없을 때
+        if(answer > cost + arr[current_node][start_node]) answer = cost + arr[current_node][start_node]; 
+        return;
+    }
+
+    // next city
+    for(int i = 0; i < N; i++) {
+        if(city[i] || arr[current_node][i] == 0) continue; // 방문 했거나 길이 없음
+        city[i] = true;
+        backtracking(start_node, i, cnt + 1, cost + arr[current_node][i]);
+        city[i] = false; 
+    }
+}
+
+int main() {
+    // input
+    ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+    cin >> N;
+
+    for(int i = 0; i < N; i++) {
+        for(int j = 0; j < N; j++) {
+            cin >> arr[i][j];
+        }
+    }
+
+    // TSP
+    for(int i = 0; i < N; i++) {
+        city[i] = true;
+        backtracking(i, i, 1, 0); // 출발지, 현재 위치, 거쳐간 마을 수, 비용
+        city[i] = false;
+    }
+
+    cout << answer;
+
+    return 0;
+}

--- a/rumos/BruteForce/BOJ_12919.cpp
+++ b/rumos/BruteForce/BOJ_12919.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+
+using namespace std;
+
+string S, T;
+bool answer = false;
+
+/**
+ * 문제에 주어진 조건대로 두 가지 연산만 수행하면서 A -> B : 시간 초과
+ * B -> A로 확인하면서 Pruning!
+*/
+
+void A_and_B(string input) {
+    // answer / stop condition
+    if(S == input) {
+        answer = true;
+        return;
+    }
+
+    if(input.size() <= S.size()) return; // B -> A 길이가 작아짐
+
+    if(input[0] == 'B') {
+        string next = input;
+        reverse(next.begin(), next.end());
+        next.pop_back();
+        A_and_B(next);
+    }
+
+    if(input[input.size() - 1] == 'A') {
+        input.pop_back();
+        A_and_B(input);
+    }
+}
+
+int main() {
+    // input
+    cin >> S >> T;
+
+    A_and_B(T); 
+
+    cout << answer;
+
+    return 0;
+}

--- a/rumos/BruteForce/BOJ_15686.cpp
+++ b/rumos/BruteForce/BOJ_15686.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+#define MAX 22222222
+
+using namespace std;
+
+
+struct House {
+	int r, c;
+};
+struct Chicken {
+	int r, c;
+	bool visited;
+};
+
+int N, M;
+int mincitydist = MAX;
+
+vector<House> house;
+vector<Chicken> chicken;
+
+void calculateDistance() {
+	int cityDistance = 0;
+	for (int i = 0; i < house.size(); i++) {
+		int minHouseDistance = MAX;
+		for (int j = 0; j < chicken.size(); j++) {
+			if (chicken[j].visited) {
+				int houseDistance = abs(house[i].r - chicken[j].r) + abs(house[i].c - chicken[j].c);
+				if (houseDistance < minHouseDistance) {
+					minHouseDistance = houseDistance;
+				}
+			}
+		}
+		cityDistance += minHouseDistance;
+	}
+	if (cityDistance < mincitydist) mincitydist = cityDistance;
+}
+
+void selectChicken(int index, int count) { 
+	if (count == M) calculateDistance();
+	for (int i = index; i < chicken.size(); i++) {
+		if (!chicken[i].visited) {
+			chicken[i].visited = true;
+			selectChicken(i, count + 1);
+			chicken[i].visited = false;
+		}
+	}
+
+}
+
+int main() {
+    // input
+	cin >> N >> M;
+    
+	int flag;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < N; j++) {
+			cin >> flag;
+			if (flag == 1) house.push_back({ i, j });
+			else if (flag == 2) chicken.push_back({ i, j, false });
+		}
+	}
+
+	selectChicken(0, 0);
+	cout << mincitydist;
+}

--- a/rumos/BruteForce/BOJ_16637.cpp
+++ b/rumos/BruteForce/BOJ_16637.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+int N;
+string S;
+int answer =  -987654321;
+
+int calculate(int a, int b, char op) {
+    switch(op) {
+        case '+' : a += b; break;
+        case '-' : a-= b; break;
+        case '*' : a *= b; break;
+    }
+
+    return a;
+}
+
+void dfs(int index, int result) {
+    // stop condition
+    if(index > N - 1) {
+        answer = max(answer, result);
+        return;
+    }
+
+    char op = (index == 0) ? '+' : S[index - 1];
+
+    // 괄호로 묶기
+    if(index + 2 < N) {
+        /**
+         * 괄호 안에 2개의 숫자만 가능
+        */
+        int next = calculate(S[index] - '0', S[index + 2] - '0', S[index + 1]); // a + b이면 a, b, +
+        dfs(index + 4, calculate(result, next, op));
+    }
+
+    // 괄호로 묶지 않고, 다음 연산자를 괄호 시작으로 정함
+    dfs(index + 2, calculate(result, S[index] - '0', op));
+}
+
+int main() {
+    // input
+    cin >> N >> S;
+
+    dfs(0, 0); // 현재 인덱스, 현재까지 계산 결과
+
+    cout << answer;
+
+    return 0;
+}

--- a/rumos/BruteForce/BOJ_17626.cpp
+++ b/rumos/BruteForce/BOJ_17626.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+int N;
+int dp[50001];
+
+int main() {
+
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    cout.tie(0);
+
+    // input
+    cin >> N;
+
+    dp[1] = 1;
+
+    for(int i = 1; i <= N; i++) {
+        dp[i] = dp[1] + dp[i - 1];
+
+        /**
+         * dp[10]의 가능한 케이스 : dp[1] + dp[9] / dp[4] + dp[6] / ... / 중 작은 값 고르기
+        */
+        for(int j = 2; j * j <= i; j++) {
+            dp[i] = min(dp[i], 1 + dp[i - j * j]);
+        }
+    }
+
+    cout << dp[N];
+
+    return 0;
+
+}

--- a/rumos/BruteForce/BOJ_2503.cpp
+++ b/rumos/BruteForce/BOJ_2503.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+
+using namespace std;
+
+bool fail[1000]; // 후보 거르기
+int a, b;
+int ans = 0;
+int N, strike, ball;
+
+void check(string str, int st, int ba){
+
+    for(int i = 123; i < 988; i++){ // 989부터는 숫자 후보가 아님
+        if(fail[i]) continue;
+        a = 0, b = 0;
+        string tmp = to_string(i);
+        for(int k = 0; k < 3; k++){
+            for(int s = 0; s < 3; s++){
+                if(str[s] == tmp[k]){
+                    if(s == k) a++;
+                    else b++;
+                }   
+            }
+        }
+        if(a != st || b != ba) {
+            fail[i] = true;
+        }
+    }
+}
+
+int main(void){
+	ios::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL);
+
+    // initialize
+    for(int i = 0; i < 1000; i++) fail[i]=false;
+
+    // input
+    string current_num;
+    cin >> N;
+    for(int i = 0; i < N; i++){
+        cin >> current_num >> strike >> ball;
+        check(current_num, strike, ball);
+    }
+
+    int num;
+    for(int i = 1; i < 10; i++){
+        for(int j = 1; j < 10; j++){
+            if(i == j) continue;
+            for(int k = 1; k < 10; k++){
+                if(k == i || k == j) continue;
+                num = i * 100 + j*10 + k;
+                if(!fail[num]) ans++;
+            }
+        }
+    }
+
+    cout << ans;
+    return 0;
+}

--- a/rumos/README.md
+++ b/rumos/README.md
@@ -87,4 +87,17 @@
 | Two Pointer | [백준 1806 : 부분합](https://www.acmicpc.net/problem/1806) |
 | Two Pointer | [백준 1644 : 소수의 연속합](https://www.acmicpc.net/problem/1644)       |
 | Two Pointer | [백준 20366 : 같이 눈사람 만들래?](https://www.acmicpc.net/problem/20366)           |
-| Two Pointer | [백준 22862 : 가장 긴 짝수 연속한 부분 수열 (large)](https://www.acmicpc.net/problem/22862)         |
+| Two Pointer | [백준 22862 : 가장 긴 짝수 연속한 부분 수열 (large)](https://www.acmicpc.net/problem/22862)       |
+
+#### Week 14 - Minimum Spanning Tree (24.06.24)
+
+| 유형          | 제목                                                                    | 풀이 |
+| ------------- | ----------------------------------------------------------------------- | :--: |
+| MST | [백준 1197 : 최소 스패닝 트리](https://www.acmicpc.net/problem/1197)         |
+| MST | [백준 1647 : 도시 분할 계획](https://www.acmicpc.net/problem/1647)        |
+| MST | [백준 9372 : 상근이의 여행](https://www.acmicpc.net/problem/9372)           |
+| MST | [백준 4386 : 별자리 만들기](https://www.acmicpc.net/problem/4386)           |
+| MST | [백준 6497 : 전력난](https://www.acmicpc.net/problem/6497) |
+| MST | [백준 1922 : 네트워크 연결](https://www.acmicpc.net/problem/1644)       |
+| MST | [백준 5014 : 스타트링크](https://www.acmicpc.net/problem/5014)           |
+| MST | [백준 18352 : 특정 거리의 도시 찾기](https://www.acmicpc.net/problem/18352)       |


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  2503 숫자 야구
- [x]  17626 Four Squares
- [x]  10971 외판원 순회
- [ ]  15661 링크와 스타트
- [x]  12919 A와 B 2
- [x]  15686 치킨 배달
- [ ]  14500 테트로미노
- [x]  16637 괄호 추가하기

## ✏️ 공부 내용

### 17626 Four Squares

브루트포스임을 의식하지 않고 풀이하려고 했고, 문제를 읽고 DP로 푸는 것이 더 나을 것 같아 DP로 풀이했다. 가능한 여러 개의 케이스 중에 min을 고른다고 하고 그대로 구현하려고 했더니 out of bound가 자꾸 났다… 케이스 하나를 잡고 손으로 해보니 금방 문제를 해결할 수 있었다.

### 10971 외판원 순회 2

backtracking을 이용해서 풀었다. 시간 초과가 나서 cin, cout tie를 풀었는데도 5%까지만 채점되고 시간 초과가 나길래 근본적인 문제가 있는 것 같아 확인해보니… 종료 조건이 backtracking 코드 안에 있는데 방문 체크 되돌리기를 backtracking 안에서 하는 엄청난 일을 저질렀다.

### 12919 A와 B 2

연산이 두 개만 있어서, BFS + 가지치기로 해결하려고 했으나 S가 길이 1, T가 길이 50일 때 2^50의 확인 작업이 필요한 것 같아 다른 방법으로 해결하려고 했다. 결론적으로 BFS + 가지치기는 시간초과가 나는 것이 맞았는데, 문제는 다른 방법을 번뜩 생각하기가 어려웠다. 

### 16637 괄호 추가하기

DFS로 풀이했다. 중첩 괄호가 안되니까, a+b+c에서 (a+b)+c, a+(b+c)의 케이스가 존재한다. 괄호의 시작을 정하면, 다음 괄호의 시작은 index + 4가 된다. 하지만 a+(b+c)와 같이 현재 피연산자는 괄호로 묶지 않고 다음 피연산자를 괄호의 시작으로 정할 수도 있다. 이때는 괄호의 시작이 index + 2이다. 이렇게 케이스를 나누니 어렵지 않았다.
Out of Bounds가 나서 다른 분들의 풀이를 보니 맨 앞 피연산자에서는 이런 식으로 연산자를 체크하더라… 한 수 배웠다!!
```bash
char op = (index == 0) ? '+' : S[index - 1];
```

## 💬 논의 사항

숫자 야구 풀어보려고 했는데 저는 왜 괄호 추가 문제보다 그게 잘 안풀릴까요...? 다음주 문제는 MST로 선정했는데, 난이도를 섞었습니다!! 앞에서부터 뒤로 차근차근 확인하시는 분들 참고해주세요!